### PR TITLE
Fix bug in WHERE clause builder

### DIFF
--- a/mysql.class.php
+++ b/mysql.class.php
@@ -326,7 +326,7 @@ class MySQL {
                 }
             } else {
                 if (is_null($value)) {
-                    $where = " AND `" . $key . "` IS NULL";
+                    $where .= " AND `" . $key . "` IS NULL";
                 } else if (is_string($key)) {
                     $where .= " AND `" . $key . "` = " . $value;
                 } else {

--- a/tests/BuildTest.php
+++ b/tests/BuildTest.php
@@ -33,6 +33,17 @@ final class BuildTest extends TestCase
         $actual = MySQL::BuildSQLSelect("test_table", $values);
         
         $this->assertSame($expected, $actual);
+
+
+        $expected = "SELECT * FROM `test_table` WHERE `id` = NULL AND `name` IS NULL AND `value` = 'foo'";
+
+        $values = [];
+        $values['id'] = MySQL::SQLValue(null);
+        $values['name'] = null;
+        $values['value'] = MySQL::SQLValue('foo', MySQL::SQLVALUE_TEXT);
+        $actual = MySQL::BuildSQLSelect('test_table', $values);
+
+        $this->assertSame($expected, $actual);
     }
     
     public function testBuildSqlSelectWithAllParameters()
@@ -55,6 +66,17 @@ final class BuildTest extends TestCase
         $filter["id"] = MySQL::SQLValue(10, MySQL::SQLVALUE_NUMBER);
         $actual = MySQL::BuildSQLUpdate("test_table", $values, $filter);
         
+        $this->assertSame($expected, $actual);
+
+
+        $expected = "UPDATE `test_table` SET `name` = 'Violet', `value` = NULL WHERE `id` = 10 AND `name` IS NULL";
+
+        $values["name"] = MySQL::SQLValue("Violet");
+        $values["value"] = MySQL::SQLValue(null);
+        $filter["id"] = MySQL::SQLValue(10, MySQL::SQLVALUE_NUMBER);
+        $filter["name"] = null;
+        $actual = MySQL::BuildSQLUpdate("test_table", $values, $filter);
+
         $this->assertSame($expected, $actual);
     }
     
@@ -80,7 +102,7 @@ final class BuildTest extends TestCase
         
         
         # 3
-        $expected = " AND `name` IS NULL";
+        $expected .= " AND `name` IS NULL";
         
         $where["name"] = null;
         $actual = MySQL::BuildSQLWhereClause($where);

--- a/tests/SeekTest.php
+++ b/tests/SeekTest.php
@@ -5,6 +5,8 @@ final class SeekTest extends TestCase
 {
     protected $db;
 
+    private static int $testTableRows = 3;
+
     public function setUp(): void
     {
         $this->db = new MySQL(true,"testdb","127.0.0.1","root","root");
@@ -55,7 +57,7 @@ final class SeekTest extends TestCase
         $this->assertTrue($this->db->BeginningOfSeek());
 
         # 3
-        $this->db->Seek(5);
+        $this->db->Seek(20);
         $this->assertFalse($this->db->BeginningOfSeek());
     }
 
@@ -63,7 +65,7 @@ final class SeekTest extends TestCase
     {
         # 1
         $this->db->Query("SELECT * FROM `test_table`");
-        $this->db->Seek(1);
+        $this->db->Seek(self::$testTableRows - 1);
         $this->assertTrue($this->db->EndOfSeek());
 
         # 2
@@ -71,7 +73,7 @@ final class SeekTest extends TestCase
         $this->assertFalse($this->db->EndOfSeek());
 
         # 3
-        $this->db->Seek(5);
+        $this->db->Seek(20);
         $this->assertFalse($this->db->EndOfSeek());
     }
 
@@ -89,7 +91,7 @@ final class SeekTest extends TestCase
 
     public function testMoveLast()
     {
-        $expected = 1;
+        $expected = self::$testTableRows - 1;
 
         $this->db->Query("SELECT * FROM `test_table`");
         $this->db->MoveLast();
@@ -126,6 +128,6 @@ final class SeekTest extends TestCase
         $this->db->Close();
         $this->db->Query("SELECT * FROM `test_table`");
         $this->db->Seek(0);
-        $this->assertFalse($this->db->MoveLast());        
-    } 
+        $this->assertFalse($this->db->MoveLast());
+    }
 }

--- a/tests/db.sql
+++ b/tests/db.sql
@@ -5,18 +5,19 @@ USE `testdb`;
 CREATE TABLE `test_query` (
   `id` int NOT NULL,
   `key` varchar(25) NOT NULL,
-  `value` varchar(50) NOT NULL
+  `value` varchar(50)
 );
 
 CREATE TABLE `test_table` (
   `id` int NOT NULL,
   `name` varchar(25) NOT NULL COMMENT 'It contains the name',
   `date` date NOT NULL,
-  `value` varchar(15) NOT NULL
+  `value` varchar(15)
 );
 
 INSERT INTO `test_table` (`id`, `name`, `date`, `value`) VALUES (1, 'John', '2022-01-01', 'Red');
 INSERT INTO `test_table` (`id`, `name`, `date`, `value`) VALUES (2, 'John2', '2022-06-01', 'Yellow');
+INSERT INTO `test_table` (`id`, `name`, `date`, `value`) VALUES (3, 'John3', '2024-01-04', NULL);
 
 ALTER TABLE `test_query`
   ADD PRIMARY KEY (`id`);
@@ -28,4 +29,4 @@ ALTER TABLE `test_query`
   MODIFY `id` int NOT NULL AUTO_INCREMENT;
 
 ALTER TABLE `test_table`
-  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;


### PR DESCRIPTION
If any but the first array elements is null it produced an invalid and incomplete WHERE clause.

Bug can become especially problematic for UPDATE statements because the resulting query can be valid with the WHERE clause missing.