### PR TITLE
Fix broken 'fetch till end of seek' loops

### DIFF
--- a/mysql.class.php
+++ b/mysql.class.php
@@ -400,7 +400,7 @@ class MySQL {
     public function EndOfSeek() {
         $this->ResetError();
         if ($this->IsConnected()) {
-            if ($this->active_row >= ($this->RowCount() - 1)) {
+            if ($this->active_row >= ($this->RowCount())) {
                 return true;
             } else {
                 return false;
@@ -1514,6 +1514,9 @@ class MySQL {
         $this->ResetError();
         $row_count = $this->RowCount();
         if (!$row_count) {
+            return false;
+        } elseif ($row_number == $row_count) {
+            $this->active_row = $row_count;
             return false;
         } elseif ($row_number >= $row_count) {
             $this->SetError("Seek parameter is greater than the total number of rows", -1);

--- a/tests/SeekTest.php
+++ b/tests/SeekTest.php
@@ -9,7 +9,7 @@ final class SeekTest extends TestCase
     {
         $this->db = new MySQL(true,"testdb","127.0.0.1","root","root");
     }
-    
+
     public function testSeek()
     {
         $expected = array("0"=>"2", "1"=>"John2", "2"=>"2022-06-01", "3"=>"Yellow");
@@ -63,7 +63,7 @@ final class SeekTest extends TestCase
     {
         # 1
         $this->db->Query("SELECT * FROM `test_table`");
-        $this->db->Seek(1);
+        $this->db->Seek(2);
         $this->assertTrue($this->db->EndOfSeek());
 
         # 2
@@ -85,6 +85,7 @@ final class SeekTest extends TestCase
         $actual = $this->db->SeekPosition();
 
         $this->assertSame($expected, $actual);
+        $this->assertTrue($this->db->BeginningOfSeek());
     }
 
     public function testMoveLast()
@@ -97,35 +98,52 @@ final class SeekTest extends TestCase
         $actual = $this->db->SeekPosition();
 
         $this->assertSame($expected, $actual);
+        $this->assertFalse($this->db->EndOfSeek());
     }
-    
+
     public function testBeginningOfSeekNoConnection()
     {
         $this->db->Close();
         $this->db->Seek(0);
-        $this->assertFalse($this->db->BeginningOfSeek());        
+        $this->assertFalse($this->db->BeginningOfSeek());
     }
-    
+
     public function testEndOfSeekNoConnection()
     {
         $this->db->Close();
         $this->db->Seek(0);
-        $this->assertFalse($this->db->EndOfSeek());        
-    }  
-    
+        $this->assertFalse($this->db->EndOfSeek());
+    }
+
     public function testMoveFirstNoConnection()
     {
         $this->db->Close();
         $this->db->Query("SELECT * FROM `test_table`");
         $this->db->Seek(0);
-        $this->assertFalse($this->db->MoveFirst());        
+        $this->assertFalse($this->db->MoveFirst());
     }
-    
+
     public function testMoveLastNoConnection()
     {
         $this->db->Close();
         $this->db->Query("SELECT * FROM `test_table`");
         $this->db->Seek(0);
-        $this->assertFalse($this->db->MoveLast());        
-    } 
+        $this->assertFalse($this->db->MoveLast());
+    }
+
+    /**
+     * Test based on some real world code which worked in version 3.0
+     * and was broken with release 4.0.
+     */
+    public function testSeekLoop()
+    {
+        $this->db->Query("SELECT * FROM `test_table`");
+        $i = 0;
+        $this->db->MoveFirst();
+        while (!$this->db->EndOfSeek()) {
+            $this->db->Row();
+            $i++;
+        }
+        $this->assertSame(2, $i);
+    }
 }

--- a/tests/SeekTest.php
+++ b/tests/SeekTest.php
@@ -65,7 +65,7 @@ final class SeekTest extends TestCase
     {
         # 1
         $this->db->Query("SELECT * FROM `test_table`");
-        $this->db->Seek(self::$testTableRows - 1);
+        $this->db->Seek(self::$testTableRows);
         $this->assertTrue($this->db->EndOfSeek());
 
         # 2
@@ -146,7 +146,7 @@ final class SeekTest extends TestCase
             $this->db->Row();
             $i++;
         }
-        $this->assertSame(2, $i);
+        $this->assertSame(self::$testTableRows, $i);
     }
 
 }


### PR DESCRIPTION
In older versions of ultimatemysql EndOfSeek returned true when no more records can be fetched. This allowed loops like

`while(!$db->EndOfSeek()) $rows[] = $db->Row();`

In the current version this is broken because EndOfSeek returns true once it points to the last record. Therefore the last record is missed in the example loop above.

This is a bug I noticed on an old PHP project where I replaced the old ultimatemysql with this PHP 8 compatible fork.