### PR TITLE
Fix GetColumnLength not working with column id and table parameter

### DIFF
--- a/mysql.class.php
+++ b/mysql.class.php
@@ -667,7 +667,8 @@ class MySQL {
                 }
             }
         } else {
-            
+            if (is_int($column))
+                $column = $this->GetColumnName($column, $table);
             try {
             $records = mysqli_query($this->mysql_link, "SELECT " . $column . " FROM " . $table . " LIMIT 1");
             } catch (mysqli_sql_exception $e) {


### PR DESCRIPTION
Found this bug by accident. A bit nasty bug because without the id to name translation the query is still valid but does not actually query the column.

The fix is copied from `GetColumnDataType`.