### PR TITLE
Fix error return value from RecordsArray

### DIFF
--- a/mysql.class.php
+++ b/mysql.class.php
@@ -1357,11 +1357,11 @@ class MySQL {
         if ($this->last_result) {
 
             if (!is_object($this->last_result))
-                return array(array());
+                return array();
 
             if (!mysqli_data_seek($this->last_result, 0)) {
                 $this->SetError();
-                return array(array());
+                return array();
             } else {
                 //while($member = mysqli_fetch_object($this->last_result)){
                 while ($member = mysqli_fetch_array($this->last_result, $resultType)) {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -316,24 +316,33 @@ final class QueryTest extends TestCase
         # 1
         $this->db->Query("SELECT `name` FROM `test_table` WHERE `id` = 1");
         $actual = $this->db->RecordsArray();
-        $this->assertIsArray($actual);      
+        $this->assertIsArray($actual);
+        $this->assertSame(1, count($actual));
         
         # 2
         $this->db->Query("SELECT `name` FROM `test_table` WHERE `id` = 100");
         $actual = $this->db->RecordsArray();
-        $this->assertIsArray($actual);    
+        $this->assertIsArray($actual);
+        $this->assertTrue(!$actual);
         
         # 3
         $this->db->Query("UPDATE `test_query` set `value`='baz' WHERE `key` = 'foo'");
         $actual = $this->db->RecordsArray();
-        $this->assertIsArray($actual);         
+        $this->assertIsArray($actual);
+        $this->assertTrue(!$actual);
         
         # 4
         $this->db->Query("SELECT `name` FROM `NonExistentTable` WHERE `id` = 100");
         $actual = $this->db->RecordsArray();
-        $this->assertFalse($actual);          
-    }    
+        $this->assertFalse($actual);
     
+        # 5
+        $this->db->Query("SELECT `name` FROM `test_table`");
+        $actual = $this->db->RecordsArray();
+        $this->assertIsArray($actual);
+        $this->assertSame($this->db->RowCount(), count($actual));
+    }
+
     public function testRow()
     {
         # 1


### PR DESCRIPTION
This one I found with some code which worked with ultimatemysql 3 and broke with 4.
In my opinion `RecordsArray` should not return a nested array for errors. This can be interpreted as one empty row and breaks code like `if (!$result)` because it evaluates to true since the array has one element.
For errors it should simple return an empty array, i.e. no rows.


PS: this is the last pull request I have. Even with the two bugs that affected me, this project saved me time making an old application PHP 8 ready. So thank you very much for your work.